### PR TITLE
ci: Labeler: Rename doc to docs

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -23,7 +23,7 @@ jobs:
               '^build':    'build',
               '^chore':    'chore',
               '^ci':       'pipeline',
-              '^doc':      'documentation',
+              '^docs':     'documentation',
               '^feat':     'feature',
               '^fix':      'fix',
               '^perf':     'performance',

--- a/.github/workflows/pull-request-rule.yaml
+++ b/.github/workflows/pull-request-rule.yaml
@@ -28,8 +28,8 @@ jobs:
             build
             chore
             ci
-            doc
-           	feat
+            docs
+            feat
             fix
             perf
             refactor


### PR DESCRIPTION
`docs` is more common and also allows **refined github** to highlight the PR prefix :)